### PR TITLE
Add dataset summary notebook

### DIFF
--- a/sumo_summary.ipynb
+++ b/sumo_summary.ipynb
@@ -1,0 +1,94 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Sumo Data Summary"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "This notebook summarizes the dataset `sumo_since_1957.csv`."
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "import pandas as pd\nimport matplotlib.pyplot as plt\n\n# Load dataset\ndf = pd.read_csv('sumo_since_1957.csv')\ndf.head()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Dataset shape\ndf.shape",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Dataset info\ndf.info()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Descriptive statistics for numerical columns\ndf.describe()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Number of unique Rikishi and Heya\nlen(df['Rikishi'].unique()), len(df['Heya'].unique())",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Top 10 Rikishi by total wins\ndf.groupby('Rikishi')['wins'].sum().sort_values(ascending=False).head(10)",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Plot distributions of height and weight\nfig, axes = plt.subplots(1,2, figsize=(12,5))\naxes[0].hist(df['height_cm'].dropna(), bins=30, color='skyblue')\naxes[0].set_title('Height Distribution')\naxes[0].set_xlabel('Height (cm)')\naxes[0].set_ylabel('Count')\n\naxes[1].hist(df['weight_kg'].dropna(), bins=30, color='salmon')\naxes[1].set_title('Weight Distribution')\naxes[1].set_xlabel('Weight (kg)')\nplt.tight_layout()\nplt.show()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Count of missing values per column\ndf.isna().sum()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Correlation matrix for numeric columns\ndf[['height_cm', 'weight_kg', 'wins', 'losses', 'ties']].corr()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Distribution of wins\nplt.figure(figsize=(6,4))\nplt.hist(df['wins'], bins=30, color='limegreen')\nplt.title('Wins Distribution')\nplt.xlabel('Wins')\nplt.ylabel('Count')\nplt.show()",
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": "# Top 10 ranks by frequency\n(df['Rank'].value_counts().head(10)\n .plot(kind='bar', figsize=(8,4), color='orange', title='Top Ranks by Frequency'))\nplt.xlabel('Rank')\nplt.ylabel('Count')\nplt.tight_layout()\nplt.show()",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- enhance `sumo_summary.ipynb` with additional summary statistics and visualizations

## Testing
- `python -m py_compile main.py sumo_scraper.py`

------
https://chatgpt.com/codex/tasks/task_e_68465469536483269857affdb08b1ce0